### PR TITLE
Add missing attributes

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/lucene/runtime/AttributeCreator.java
+++ b/runtime/src/main/java/io/quarkiverse/lucene/runtime/AttributeCreator.java
@@ -1,6 +1,22 @@
 package io.quarkiverse.lucene.runtime;
 
-import org.apache.lucene.analysis.tokenattributes.*;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.PackedTokenAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.PositionLengthAttribute;
+import org.apache.lucene.analysis.tokenattributes.PositionLengthAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
+import org.apache.lucene.analysis.tokenattributes.TypeAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.KeywordAttribute;
+import org.apache.lucene.analysis.tokenattributes.KeywordAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.PayloadAttribute;
+import org.apache.lucene.analysis.tokenattributes.PayloadAttributeImpl;
 import org.apache.lucene.search.BoostAttribute;
 import org.apache.lucene.search.BoostAttributeImpl;
 import org.apache.lucene.util.Attribute;

--- a/runtime/src/main/java/io/quarkiverse/lucene/runtime/AttributeCreator.java
+++ b/runtime/src/main/java/io/quarkiverse/lucene/runtime/AttributeCreator.java
@@ -1,18 +1,6 @@
 package io.quarkiverse.lucene.runtime;
 
-import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
-import org.apache.lucene.analysis.tokenattributes.CharTermAttributeImpl;
-import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
-import org.apache.lucene.analysis.tokenattributes.OffsetAttributeImpl;
-import org.apache.lucene.analysis.tokenattributes.PackedTokenAttributeImpl;
-import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
-import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttributeImpl;
-import org.apache.lucene.analysis.tokenattributes.PositionLengthAttribute;
-import org.apache.lucene.analysis.tokenattributes.PositionLengthAttributeImpl;
-import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
-import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttributeImpl;
-import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
-import org.apache.lucene.analysis.tokenattributes.TypeAttributeImpl;
+import org.apache.lucene.analysis.tokenattributes.*;
 import org.apache.lucene.search.BoostAttribute;
 import org.apache.lucene.search.BoostAttributeImpl;
 import org.apache.lucene.util.Attribute;
@@ -40,6 +28,8 @@ public final class AttributeCreator {
             return new PositionLengthAttributeImpl();
         } else if (attClass == BoostAttribute.class) {
             return new BoostAttributeImpl();
+        } else if (attClass == KeywordAttribute.class) {
+            return new KeywordAttributeImpl();
         }
         throw new UnsupportedOperationException(
                 String.format("Attribute class '%s' not supported in the image", attClass));

--- a/runtime/src/main/java/io/quarkiverse/lucene/runtime/AttributeCreator.java
+++ b/runtime/src/main/java/io/quarkiverse/lucene/runtime/AttributeCreator.java
@@ -30,6 +30,8 @@ public final class AttributeCreator {
             return new BoostAttributeImpl();
         } else if (attClass == KeywordAttribute.class) {
             return new KeywordAttributeImpl();
+        } else if (attClass == PayloadAttribute.class) {
+            return new PayloadAttributeImpl();
         }
         throw new UnsupportedOperationException(
                 String.format("Attribute class '%s' not supported in the image", attClass));


### PR DESCRIPTION
For the [lucene-grep](https://github.com/dainiusjocas/lucene-grep) to compile the `KeywordAttribute` and `PayloadAttribute` are needed.