### PR TITLE
Fix #106: Handle reflection classes more dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
+[![Version](https://img.shields.io/maven-central/v/io.quarkiverse.lucene/quarkus-lucene?logo=apache-maven&style=flat-square)](https://search.maven.org/artifact/io.quarkiverse.lucene/quarkus-lucene)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](https://opensource.org/licenses/Apache-2.0)
+
 [Apache Lucene](https://lucene.apache.org/) is a Java library providing powerful indexing and search features, as well as spellchecking, hit highlighting and advanced analysis/tokenization capabilities. 
 
 This extension adds support for native images when using Apache Lucene for both Java 8 and 11 and GraalVM 20.0 and 21.0.

--- a/deployment/src/main/java/io/quarkiverse/lucene/deployment/LuceneProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/lucene/deployment/LuceneProcessor.java
@@ -1,34 +1,23 @@
 package io.quarkiverse.lucene.deployment;
 
-import org.apache.lucene.analysis.charfilter.MappingCharFilterFactory;
-import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
-import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
-import org.apache.lucene.analysis.core.StopFilterFactory;
-import org.apache.lucene.analysis.core.UpperCaseFilterFactory;
-import org.apache.lucene.analysis.core.WhitespaceTokenizerFactory;
-import org.apache.lucene.analysis.en.PorterStemFilterFactory;
-import org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilterFactory;
-import org.apache.lucene.analysis.ngram.EdgeNGramFilterFactory;
-import org.apache.lucene.analysis.ngram.EdgeNGramTokenizerFactory;
-import org.apache.lucene.analysis.ngram.NGramFilterFactory;
-import org.apache.lucene.analysis.ngram.NGramTokenizerFactory;
-import org.apache.lucene.analysis.path.PathHierarchyTokenizerFactory;
-import org.apache.lucene.analysis.pattern.PatternReplaceCharFilterFactory;
-import org.apache.lucene.analysis.pattern.PatternReplaceFilterFactory;
-import org.apache.lucene.analysis.pattern.PatternTokenizerFactory;
-import org.apache.lucene.analysis.shingle.ShingleFilterFactory;
-import org.apache.lucene.analysis.snowball.SnowballPorterFilterFactory;
-import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
-import org.apache.lucene.analysis.synonym.SynonymGraphFilterFactory;
-import org.apache.lucene.analysis.util.CharFilterFactory;
-import org.apache.lucene.store.ByteBuffersDirectory;
-import org.apache.lucene.store.MMapDirectory;
-import org.apache.lucene.store.NIOFSDirectory;
-import org.tartarus.snowball.ext.EnglishStemmer;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.lucene.analysis.util.AbstractAnalysisFactory;
+import org.apache.lucene.analysis.util.TokenFilterFactory;
+import org.apache.lucene.analysis.util.TokenizerFactory;
+import org.apache.lucene.store.BaseDirectory;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.tartarus.snowball.SnowballProgram;
 
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 
 class LuceneProcessor {
@@ -41,47 +30,56 @@ class LuceneProcessor {
     }
 
     @BuildStep
-    @SuppressWarnings("deprecation")
-    void commonTokenizerReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass) {
-        addCtorReflection(reflectiveClass, StandardTokenizerFactory.class);
-        addCtorReflection(reflectiveClass, LowerCaseFilterFactory.class);
-        addCtorReflection(reflectiveClass, EdgeNGramTokenizerFactory.class);
-        addCtorReflection(reflectiveClass, PathHierarchyTokenizerFactory.class);
-        addCtorReflection(reflectiveClass, WhitespaceTokenizerFactory.class);
-        addCtorReflection(reflectiveClass, PatternTokenizerFactory.class);
-        addCtorReflection(reflectiveClass, KeywordTokenizerFactory.class);
-        addCtorReflection(reflectiveClass, NGramTokenizerFactory.class);
-        // Filter Factories
-        addCtorReflection(reflectiveClass, EdgeNGramFilterFactory.class);
-        addCtorReflection(reflectiveClass, LowerCaseFilterFactory.class);
-        addCtorReflection(reflectiveClass, ShingleFilterFactory.class);
-        addCtorReflection(reflectiveClass, StopFilterFactory.class);
-        addCtorReflection(reflectiveClass, SynonymGraphFilterFactory.class);
-        addCtorReflection(reflectiveClass, SnowballPorterFilterFactory.class);
-        addCtorReflection(reflectiveClass, UpperCaseFilterFactory.class);
-        addCtorReflection(reflectiveClass, PatternReplaceFilterFactory.class);
-        addCtorReflection(reflectiveClass, PorterStemFilterFactory.class);
-        addCtorReflection(reflectiveClass, NGramFilterFactory.class);
-        addCtorReflection(reflectiveClass, ShingleFilterFactory.class);
-        addCtorReflection(reflectiveClass, WordDelimiterGraphFilterFactory.class);
-
-        // Stemmers
-        addCtorReflection(reflectiveClass, EnglishStemmer.class);
-        // Char filter factories
-        addCtorReflection(reflectiveClass, CharFilterFactory.class);
-        addCtorReflection(reflectiveClass, MappingCharFilterFactory.class);
-        addCtorReflection(reflectiveClass, PatternReplaceCharFilterFactory.class);
-
-        // Directories
-        addCtorReflection(reflectiveClass, MMapDirectory.class);
-        addCtorReflection(reflectiveClass, ByteBuffersDirectory.class);
-        addCtorReflection(reflectiveClass, NIOFSDirectory.class);
-        // Include deprecated directories for now
-        addCtorReflection(reflectiveClass, org.apache.lucene.store.RAMDirectory.class);
-        addCtorReflection(reflectiveClass, org.apache.lucene.store.SimpleFSDirectory.class);
+    void indexTransitiveDependencies(BuildProducer<IndexDependencyBuildItem> index) {
+        index.produce(new IndexDependencyBuildItem("org.apache.lucene", "lucene-core"));
+        index.produce(new IndexDependencyBuildItem("org.apache.lucene", "lucene-analyzers-common"));
+        index.produce(new IndexDependencyBuildItem("org.apache.lucene", "lucene-queryparser"));
     }
 
-    private void addCtorReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, Class<?> clazz) {
-        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, clazz));
+    @BuildStep
+    void commonTokenizerReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass,
+            CombinedIndexBuildItem combinedIndex) {
+        Set<String> classNames = new HashSet<>();
+
+        // Token Factories
+        classNames.addAll(collectSubclasses(combinedIndex, TokenizerFactory.class.getName()));
+
+        // Filter Factories
+        classNames.addAll(collectSubclasses(combinedIndex, TokenFilterFactory.class.getName()));
+
+        // Stemmers
+        classNames.addAll(collectSubclasses(combinedIndex, SnowballProgram.class.getName()));
+
+        // Char filter factories
+        classNames.addAll(collectSubclasses(combinedIndex, AbstractAnalysisFactory.class.getName()));
+
+        // Directories
+        classNames.addAll(collectSubclasses(combinedIndex, BaseDirectory.class.getName()));
+
+        addCtorReflection(reflectiveClass, classNames);
+    }
+
+    private void addCtorReflection(BuildProducer<ReflectiveClassBuildItem> reflectiveClass, Set<String> classNames) {
+        reflectiveClass.produce(new ReflectiveClassBuildItem(true, false, false, classNames.toArray(new String[0])));
+    }
+
+    private List<String> collectSubclasses(CombinedIndexBuildItem combinedIndex, String className) {
+        List<String> classes = combinedIndex.getIndex()
+                .getAllKnownSubclasses(DotName.createSimple(className))
+                .stream()
+                .map(ClassInfo::toString)
+                .collect(Collectors.toList());
+        classes.add(className);
+        return classes;
+    }
+
+    private List<String> collectImplementors(CombinedIndexBuildItem combinedIndex, String className) {
+        List<String> classes = combinedIndex.getIndex()
+                .getAllKnownImplementors(DotName.createSimple(className))
+                .stream()
+                .map(ClassInfo::toString)
+                .collect(Collectors.toList());
+        classes.add(className);
+        return classes;
     }
 }

--- a/integration-test/src/test/java/io/quarkiverse/lucene/it/LuceneFunctionalityInGraalITCase.java
+++ b/integration-test/src/test/java/io/quarkiverse/lucene/it/LuceneFunctionalityInGraalITCase.java
@@ -1,7 +1,7 @@
 package io.quarkiverse.lucene.it;
 
-import io.quarkus.test.junit.NativeImageTest;
+import io.quarkus.test.junit.QuarkusIntegrationTest;
 
-@NativeImageTest
+@QuarkusIntegrationTest
 public class LuceneFunctionalityInGraalITCase extends LuceneFunctionalityTest {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
       <maven.compiler.target>1.8</maven.compiler.target>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-      <quarkus.version>2.16.3.Final</quarkus.version>
+      <quarkus.version>2.16.6.Final</quarkus.version>
       <lucene.version>8.11.2</lucene.version>
    </properties>
    <dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -1,75 +1,69 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-   <modelVersion>4.0.0</modelVersion>
-   <parent>
-      <groupId>io.quarkiverse.lucene</groupId>
-      <artifactId>quarkus-lucene-parent</artifactId>
-      <version>0.5-SNAPSHOT</version>
-   </parent>
-   <artifactId>quarkus-lucene</artifactId>
-   <name>Quarkus - Lucene - Runtime</name>
-   <description>Add full-text search capabilities to your application with Apache Lucene.</description>
-
-   <dependencies>
-      <!-- Quarkus dependencies -->
-      <dependency>
-         <groupId>io.quarkus</groupId>
-         <artifactId>quarkus-arc</artifactId>
-      </dependency>
-
-      <!--GraalVM -->
-      <dependency>
-         <groupId>org.graalvm.nativeimage</groupId>
-         <artifactId>svm</artifactId>
-      </dependency>
-
-      <!-- Lucene dependencies -->
-      <dependency>
-         <groupId>org.apache.lucene</groupId>
-         <artifactId>lucene-core</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.lucene</groupId>
-         <artifactId>lucene-analyzers-common</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>org.apache.lucene</groupId>
-         <artifactId>lucene-queryparser</artifactId>
-      </dependency>
-   </dependencies>
-
-   <build>
-      <plugins>
-         <plugin>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.quarkiverse.lucene</groupId>
+        <artifactId>quarkus-lucene-parent</artifactId>
+        <version>0.5-SNAPSHOT</version>
+    </parent>
+    <artifactId>quarkus-lucene</artifactId>
+    <name>Quarkus - Lucene - Runtime</name>
+    <description>Add full-text search capabilities to your application with Apache Lucene.</description>
+    <dependencies>
+        <!-- Quarkus dependencies -->
+        <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-bootstrap-maven-plugin</artifactId>
-            <version>${quarkus.version}</version>
-            <executions>
-               <execution>
-                  <goals>
-                     <goal>extension-descriptor</goal>
-                  </goals>
-                  <phase>compile</phase>
-                  <configuration>
-                     <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}
-                     </deployment>
-                  </configuration>
-               </execution>
-            </executions>
-         </plugin>
-         <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-               <annotationProcessorPaths>
-                  <path>
-                     <groupId>io.quarkus</groupId>
-                     <artifactId>quarkus-extension-processor</artifactId>
-                     <version>${quarkus.version}</version>
-                  </path>
-               </annotationProcessorPaths>
-            </configuration>
-         </plugin>
-      </plugins>
-   </build>
+            <artifactId>quarkus-arc</artifactId>
+        </dependency>
+        <!--GraalVM -->
+        <dependency>
+            <groupId>org.graalvm.nativeimage</groupId>
+            <artifactId>svm</artifactId>
+        </dependency>
+        <!-- Lucene dependencies -->
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Fix #106: Handle reflection classes more dynamically

Uses Jandex to collect subclasses rather than list each class individually. Also future proofs it for new Lucene classes.