### PR TITLE
fix: add attributes.adoc file

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,0 +1,16 @@
+:quarkus-version: 3.0.0.Final
+:quarkus-lucene-version: 3.0.0
+:maven-version: 3.8.1+
+
+:quarkus-org-url: https://github.com/quarkusio
+:quarkus-base-url: {quarkus-org-url}/quarkus
+:quarkus-clone-url: {quarkus-base-url}.git
+:quarkus-archive-url: {quarkus-base-url}/archive/master.zip
+:quarkus-tree-url: {quarkus-base-url}/tree/main
+:quarkus-issues-url: {quarkus-base-url}/issues
+:quarkus-guides-url: https://quarkus.io/guides
+:quickstarts-base-url: https://github.com/quarkusio/quarkus-quickstarts
+:quickstarts-clone-url: https://github.com/quarkusio/quarkus-quickstarts.git
+:quickstarts-archive-url: https://github.com/quarkusio/quarkus-quickstarts/archive/main.zip
+:quickstarts-blob-url: https://github.com/quarkusio/quarkus-quickstarts/blob/main
+:quickstarts-tree-url: https://github.com/quarkusio/quarkus-quickstarts/tree/main


### PR DESCRIPTION
It seems that this file caused release to crash https://github.com/quarkiverse/quarkus-lucene/actions/runs/4785820235/jobs/8508993001

Adding a file with an example of https://github.com/quarkiverse/quarkus-renarde/blob/32e90be25c94bed800e4c997abd1b84ae16354bd/docs/modules/ROOT/pages/includes/attributes.adoc#L4