### PR TITLE
Release 2.1.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,4 @@
 name: Quarkiverse Extension
 release:
-  current-version: 2.0
-  next-version: 2.1-SNAPSHOT
-
+  current-version: 2.1.0
+  next-version: 2.2.0-SNAPSHOT


### PR DESCRIPTION
Upgrade:
- [Lucene 9.6.0](https://lucene.apache.org/core/corenews.html#apache-lucenetm-960-available)
- [Quarkus to 3.0.3.Final](https://quarkus.io/blog/quarkus-3-0-3-final-released/)

Also, I've changed versioning scheme to the semantic versioning. That should prevent bugs where 2.0 is released as just "2" closes #125 