### PR TITLE
Use `graal-sdk` instead of `svm`

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -17,8 +17,8 @@
         </dependency>
         <!--GraalVM -->
         <dependency>
-            <groupId>org.graalvm.nativeimage</groupId>
-            <artifactId>svm</artifactId>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>graal-sdk</artifactId>
         </dependency>
         <!-- Lucene dependencies -->
         <dependency>


### PR DESCRIPTION
- Caused by https://github.com/quarkusio/quarkus/pull/34145